### PR TITLE
Cap lint levels for rustc

### DIFF
--- a/mkRustCrate/lib/mkRustCrate/wrapper.sh
+++ b/mkRustCrate/lib/mkRustCrate/wrapper.sh
@@ -28,4 +28,4 @@ then
 fi
 
 >&2 echo @cmd@ $depFlags "${args[@]}"
-env @cmd@ $depFlags "${args[@]}"
+env @cmd@ --cap-lints warn $depFlags "${args[@]}"


### PR DESCRIPTION
A quick hardcode capping lints to warn.
Some crate authors think they know best and set "deny(warnings)", which means
that if we get a warning compiling this crate, the compile will fail.
Annoying !

In a "normal" cargo compile, cargo knows when a crate is upstream and then sets "--cap-lints" on rustc.
However, how that would work for mkRustCrate, I have no idea...
Might be as simple as adding a "source = ..." line to Cargo.lock...

A better solution would, of course, be to let cargo add the "--cap-lints" options itself on upstream crates, instead of hard coding.